### PR TITLE
Make setting the prompt available from ShellServer via a shellHandler.

### DIFF
--- a/src/main/java/io/vertx/ext/shell/ShellServer.java
+++ b/src/main/java/io/vertx/ext/shell/ShellServer.java
@@ -143,4 +143,15 @@ public interface ShellServer {
    */
   void close(Handler<AsyncResult<Void>> completionHandler);
 
+
+  /**
+   * Called when a new shell is created. Can be used to prepopulate the shell session with objects
+   * or set the prompt.
+   *
+   * @param shellHandler handler for getting notified when the server creates a new shell.
+   */
+  void shellHandler(Handler<Shell> shellHandler);
+
+
+
 }

--- a/src/main/java/io/vertx/ext/shell/impl/ShellServerImpl.java
+++ b/src/main/java/io/vertx/ext/shell/impl/ShellServerImpl.java
@@ -76,6 +76,7 @@ public class ShellServerImpl implements ShellServer {
   private long timerID = -1;
   private final Map<String, ShellImpl> sessions;
   private final Future<Void> sessionsClosed = Future.future();
+  private Handler<Shell> shellHandler;
 
   public ShellServerImpl(Vertx vertx, ShellServerOptions options) {
     this.vertx = vertx;
@@ -130,6 +131,9 @@ public class ShellServerImpl implements ShellServer {
       }
     });
     session.init();
+    if (shellHandler != null) {
+      shellHandler.handle(session);
+    }
     sessions.put(session.id, session); // Put after init so the close handler on the connection is set
     session.readline(); // Now readline
   }
@@ -251,5 +255,10 @@ public class ShellServerImpl implements ShellServer {
       toStop.forEach(termServer -> termServer.close(handler));
       sessionsClosed.setHandler(handler);
     }
+  }
+
+  @Override
+  public void shellHandler(Handler<Shell> shellHandler) {
+    this.shellHandler = shellHandler;
   }
 }

--- a/src/test/java/io/vertx/ext/shell/ShellServerPromptTest.java
+++ b/src/test/java/io/vertx/ext/shell/ShellServerPromptTest.java
@@ -1,0 +1,71 @@
+package io.vertx.ext.shell;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.shell.command.CommandBuilder;
+import io.vertx.ext.shell.command.CommandResolver;
+import io.vertx.ext.shell.support.TestCommands;
+import io.vertx.ext.shell.support.TestTermServer;
+import io.vertx.ext.shell.support.TestTtyConnection;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@RunWith(VertxUnitRunner.class)
+public class ShellServerPromptTest {
+  private Vertx vertx;
+  private TestCommands commands;
+
+  @Before
+  public void before() {
+    vertx = Vertx.vertx();
+    commands = new TestCommands(vertx);
+    //server = ShellServer.create(vertx).registerCommandResolver(commands);
+  }
+
+   @After
+  public void after(TestContext context) {
+    vertx.close(context.asyncAssertSuccess());
+  }
+
+  @Test
+  public void testPrompt(TestContext context) {
+    commands = new TestCommands(vertx);
+    ShellServer server =  ShellServer.create(vertx, new ShellServerOptions()
+      .setWelcomeMessage("")
+      .setSessionTimeout(100)
+      .setReaperInterval(100));
+    server.shellHandler(shell -> shell.setPrompt(s -> "FOOPROMPT"));
+    TestTermServer termServer = new TestTermServer(vertx);
+    server.registerTermServer(termServer);
+    server.
+      registerCommandResolver(CommandResolver.baseCommands(vertx)).
+      registerCommandResolver(commands).
+      listen(context.asyncAssertSuccess());
+
+    TestTtyConnection conn = termServer.openConnection();
+
+    Async async = context.async();
+    commands.add(CommandBuilder.command("foo").processHandler(process -> {
+      context.assertEquals(null, conn.checkWritten("FOOPROMPTfoo\n"));
+      process.stdinHandler(cp -> {
+        context.fail();
+      });
+      process.endHandler(v -> {
+          async.complete();
+        }
+      );
+      process.end();
+
+    }));
+    conn.read("foo\r");
+    async.awaitSuccess(5000);
+  }
+
+}

--- a/src/test/java/io/vertx/ext/shell/command/base/BusTest.java
+++ b/src/test/java/io/vertx/ext/shell/command/base/BusTest.java
@@ -131,7 +131,7 @@ public class BusTest {
       context.assertEquals("the_message", msg.body());
       consumerAsync.complete();
     });
-    context.assertEquals("Error: Timed out after waiting 50(ms) for a reply. address: 1, repliedAddress: the_address\n", result);
+    context.assertEquals("Error: Timed out after waiting 50(ms) for a reply. address: __vertx.reply.1, repliedAddress: the_address\n", result);
   }
 
   @Test


### PR DESCRIPTION
This works now.

    ShellServer server = ShellServer.create(vertx);
    AtomicInteger ai = new AtomicInteger(0);
    server.shellHandler(shell -> {
      shell.setPrompt(s -> {
        try {
          return "C: " + ai.incrementAndGet();
        } catch (Exception e) {
          System.err.println("Counter");
          e.printStackTrace();
        }
        return "NOOP";
      });
    });
    TelnetTermOptions tto = new TelnetTermOptions().setPort(3000).setHost("localhost");
    TermServer telnetTermServer = TermServer.createTelnetTermServer(vertx,tto);
    server.registerTermServer(telnetTermServer);

    server.registerCommandResolver(CommandResolver.baseCommands(vertx));

    server.listen(ar -> {
      if (!ar.succeeded()) {
        ar.cause().printStackTrace();
      }
    });