### PR TITLE
Avoid depending on AuthOptions as a way to instantiate a auth provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,11 +152,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-mongo-client</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>de.flapdoodle.embed</groupId>
       <artifactId>de.flapdoodle.embed.mongo</artifactId>
       <version>2.0.3</version>
@@ -168,7 +163,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-
   </dependencies>
 
   <build>

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -15,8 +15,8 @@
 |[[acceptBacklog]]`@acceptBacklog`|`Number (int)`|-
 |[[acceptUnmaskedFrames]]`@acceptUnmaskedFrames`|`Boolean`|-
 |[[alpnVersions]]`@alpnVersions`|`Array of link:enums.html#HttpVersion[HttpVersion]`|-
-|[[authOptions]]`@authOptions`|`link:dataobjects.html#AuthOptions[AuthOptions]`|+++
-
+|[[authOptions]]`@authOptions`|`Json object`|+++
+Set the auth options.
 +++
 |[[charset]]`@charset`|`String`|+++
 Set the charset used for encoding / decoding text data from/to SockJS
@@ -105,8 +105,8 @@ Set <code>vertxshell.js</code> resource to use.
 [frame="topbot"]
 |===
 ^|Name | Type ^| Description
-|[[authOptions]]`@authOptions`|`link:dataobjects.html#AuthOptions[AuthOptions]`|+++
-
+|[[authOptions]]`@authOptions`|`Json object`|+++
+Set the auth options.
 +++
 |[[defaultCharset]]`@defaultCharset`|`String`|+++
 Set the default charset to use when the client does not specifies one.

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -110,7 +110,7 @@ providers:
 - _jdbc_ : JDBC backend
 - _mongo_ : MongoDB backend
 
-These options can be created directly using directly {@link io.vertx.ext.auth.AuthOptions}:
+These options can be created directly using directly corresponding class:
 
 - {@link io.vertx.ext.auth.shiro.ShiroAuthOptions} for Shiro
 - {@link io.vertx.ext.auth.jdbc.JDBCAuthOptions} for JDBC
@@ -537,7 +537,7 @@ Vert.x Shell also provides bare terminal servers for those who need to write pur
 A {@link io.vertx.ext.shell.term.Term} handler must be set on a term server before starting it. This handler will
 handle each term when the user connects.
 
-An {@link io.vertx.ext.auth.AuthOptions} can be set on {@link io.vertx.ext.shell.term.SSHTermOptions} and {@link io.vertx.ext.shell.term.HttpTermOptions}.
+An {@code Auth*Options} can be set on {@link io.vertx.ext.shell.term.SSHTermOptions} and {@link io.vertx.ext.shell.term.HttpTermOptions}.
 Alternatively, an {@link io.vertx.ext.auth.AuthProvider} can be {@link io.vertx.ext.shell.term.TermServer#authProvider(io.vertx.ext.auth.AuthProvider) set}
 directly on the term server before starting it.
 

--- a/src/main/generated/io/vertx/ext/shell/term/HttpTermOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/shell/term/HttpTermOptionsConverter.java
@@ -15,6 +15,11 @@ public class HttpTermOptionsConverter {
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, HttpTermOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
+        case "authOptions":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setAuthOptions(((JsonObject)member.getValue()).copy());
+          }
+          break;
         case "charset":
           if (member.getValue() instanceof String) {
             obj.setCharset((String)member.getValue());
@@ -59,6 +64,9 @@ public class HttpTermOptionsConverter {
   }
 
   public static void toJson(HttpTermOptions obj, java.util.Map<String, Object> json) {
+    if (obj.getAuthOptions() != null) {
+      json.put("authOptions", obj.getAuthOptions());
+    }
     if (obj.getCharset() != null) {
       json.put("charset", obj.getCharset());
     }

--- a/src/main/generated/io/vertx/ext/shell/term/SSHTermOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/shell/term/SSHTermOptionsConverter.java
@@ -15,6 +15,11 @@ public class SSHTermOptionsConverter {
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, SSHTermOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
+        case "authOptions":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setAuthOptions(((JsonObject)member.getValue()).copy());
+          }
+          break;
         case "defaultCharset":
           if (member.getValue() instanceof String) {
             obj.setDefaultCharset((String)member.getValue());
@@ -59,6 +64,9 @@ public class SSHTermOptionsConverter {
   }
 
   public static void toJson(SSHTermOptions obj, java.util.Map<String, Object> json) {
+    if (obj.getAuthOptions() != null) {
+      json.put("authOptions", obj.getAuthOptions());
+    }
     if (obj.getDefaultCharset() != null) {
       json.put("defaultCharset", obj.getDefaultCharset());
     }

--- a/src/main/java/examples/ShellExamples.java
+++ b/src/main/java/examples/ShellExamples.java
@@ -40,25 +40,16 @@ import io.vertx.core.cli.CommandLine;
 import io.vertx.core.cli.Option;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.JksOptions;
-import io.vertx.ext.auth.jdbc.JDBCAuthOptions;
-import io.vertx.ext.auth.mongo.MongoAuthOptions;
-import io.vertx.ext.auth.shiro.ShiroAuthOptions;
-import io.vertx.ext.auth.shiro.ShiroAuthRealmType;
 import io.vertx.ext.shell.Shell;
 import io.vertx.ext.shell.ShellServer;
-import io.vertx.ext.shell.command.CommandResolver;
-import io.vertx.ext.shell.term.HttpTermOptions;
-import io.vertx.ext.shell.term.Pty;
-import io.vertx.ext.shell.term.Tty;
-import io.vertx.ext.shell.system.Job;
-import io.vertx.ext.shell.term.SSHTermOptions;
-import io.vertx.ext.shell.session.Session;
 import io.vertx.ext.shell.ShellService;
 import io.vertx.ext.shell.ShellServiceOptions;
-import io.vertx.ext.shell.term.TelnetTermOptions;
 import io.vertx.ext.shell.command.CommandBuilder;
 import io.vertx.ext.shell.command.CommandRegistry;
-import io.vertx.ext.shell.term.TermServer;
+import io.vertx.ext.shell.command.CommandResolver;
+import io.vertx.ext.shell.session.Session;
+import io.vertx.ext.shell.system.Job;
+import io.vertx.ext.shell.term.*;
 import io.vertx.ext.web.Router;
 
 /**
@@ -68,226 +59,235 @@ public class ShellExamples {
 
   public void deployTelnetService(Vertx vertx) throws Exception {
     vertx.deployVerticle("maven:{maven-groupId}:{maven-artifactId}:{maven-version}",
-        new DeploymentOptions().setConfig(
-            new JsonObject().put("telnetOptions",
-                new JsonObject().
-                    put("host", "localhost").
-                    put("port", 4000))
-        )
+      new DeploymentOptions().setConfig(
+        new JsonObject().put("telnetOptions",
+          new JsonObject().
+            put("host", "localhost").
+            put("port", 4000))
+      )
     );
   }
 
   public void deploySSHServiceWithShiro(Vertx vertx) throws Exception {
     vertx.deployVerticle("maven:{maven-groupId}:{maven-artifactId}:{maven-version}",
-        new DeploymentOptions().setConfig(new JsonObject().
-                put("sshOptions", new JsonObject().
-                    put("host", "localhost").
-                    put("port", 5000).
-                    put("keyPairOptions", new JsonObject().
-                        put("path", "src/test/resources/ssh.jks").
-                        put("password", "wibble")).
-                    put("authOptions", new JsonObject().
-                        put("provider", "shiro").
-                        put("config", new JsonObject().
-                            put("properties_path", "file:/path/to/my/auth.properties"))))
-        )
+      new DeploymentOptions().setConfig(new JsonObject().
+        put("sshOptions", new JsonObject().
+          put("host", "localhost").
+          put("port", 5000).
+          put("keyPairOptions", new JsonObject().
+            put("path", "src/test/resources/ssh.jks").
+            put("password", "wibble")).
+          put("authOptions", new JsonObject().
+            put("provider", "shiro").
+            put("config", new JsonObject().
+              put("properties_path", "file:/path/to/my/auth.properties"))))
+      )
     );
   }
 
   public void deploySSHServiceWithJDBC(Vertx vertx) throws Exception {
     vertx.deployVerticle("maven:{maven-groupId}:{maven-artifactId}:{maven-version}",
-        new DeploymentOptions().setConfig(new JsonObject().
-                put("sshOptions", new JsonObject().
-                    put("host", "localhost").
-                    put("port", 5000).
-                    put("keyPairOptions", new JsonObject().
-                        put("path", "src/test/resources/ssh.jks").
-                        put("password", "wibble")).
-                    put("authOptions", new JsonObject().
-                        put("provider", "jdbc").
-                        put("config", new JsonObject()
-                            .put("url", "jdbc:hsqldb:mem:test?shutdown=true")
-                            .put("driver_class", "org.hsqldb.jdbcDriver"))))
-        )
+      new DeploymentOptions().setConfig(new JsonObject().
+        put("sshOptions", new JsonObject().
+          put("host", "localhost").
+          put("port", 5000).
+          put("keyPairOptions", new JsonObject().
+            put("path", "src/test/resources/ssh.jks").
+            put("password", "wibble")).
+          put("authOptions", new JsonObject().
+            put("provider", "jdbc").
+            put("config", new JsonObject()
+              .put("url", "jdbc:hsqldb:mem:test?shutdown=true")
+              .put("driver_class", "org.hsqldb.jdbcDriver"))))
+      )
     );
   }
 
   public void deploySSHServiceWithMongo(Vertx vertx) throws Exception {
     vertx.deployVerticle("maven:{maven-groupId}:{maven-artifactId}:{maven-version}",
-        new DeploymentOptions().setConfig(new JsonObject().
-                put("sshOptions", new JsonObject().
-                    put("host", "localhost").
-                    put("port", 5000).
-                    put("keyPairOptions", new JsonObject().
-                        put("path", "src/test/resources/ssh.jks").
-                        put("password", "wibble")).
-                    put("authOptions", new JsonObject().
-                        put("provider", "mongo").
-                        put("config", new JsonObject().
-                            put("connection_string", "mongodb://localhost:27018"))))
-        )
+      new DeploymentOptions().setConfig(new JsonObject().
+        put("sshOptions", new JsonObject().
+          put("host", "localhost").
+          put("port", 5000).
+          put("keyPairOptions", new JsonObject().
+            put("path", "src/test/resources/ssh.jks").
+            put("password", "wibble")).
+          put("authOptions", new JsonObject().
+            put("provider", "mongo").
+            put("config", new JsonObject().
+              put("connection_string", "mongodb://localhost:27018"))))
+      )
     );
   }
 
   public void deployHttpServiceWithShiro(Vertx vertx) throws Exception {
     vertx.deployVerticle("maven:{maven-groupId}:{maven-artifactId}:{maven-version}",
-        new DeploymentOptions().setConfig(new JsonObject().
-                put("httpOptions", new JsonObject().
-                    put("host", "localhost").
-                    put("port", 8080).
-                    put("ssl", true).
-                    put("keyPairOptions", new JsonObject().
-                        put("path", "src/test/resources/server-keystore.jks").
-                        put("password", "wibble")).
-                    put("authOptions", new JsonObject().
-                        put("provider", "shiro").
-                        put("config", new JsonObject().
-                            put("properties_path", "file:/path/to/my/auth.properties"))))
-        )
+      new DeploymentOptions().setConfig(new JsonObject().
+        put("httpOptions", new JsonObject().
+          put("host", "localhost").
+          put("port", 8080).
+          put("ssl", true).
+          put("keyPairOptions", new JsonObject().
+            put("path", "src/test/resources/server-keystore.jks").
+            put("password", "wibble")).
+          put("authOptions", new JsonObject().
+            put("provider", "shiro").
+            put("config", new JsonObject().
+              put("properties_path", "file:/path/to/my/auth.properties"))))
+      )
     );
   }
 
   public void deployHttpServiceWithJDBC(Vertx vertx) throws Exception {
     vertx.deployVerticle("maven:{maven-groupId}:{maven-artifactId}:{maven-version}",
-        new DeploymentOptions().setConfig(new JsonObject().
-                put("httpOptions", new JsonObject().
-                    put("host", "localhost").
-                    put("port", 8080).
-                    put("ssl", true).
-                    put("keyPairOptions", new JsonObject().
-                        put("path", "src/test/resources/server-keystore.jks").
-                        put("password", "wibble")).
-                    put("authOptions", new JsonObject().
-                        put("provider", "jdbc").
-                        put("config", new JsonObject()
-                            .put("url", "jdbc:hsqldb:mem:test?shutdown=true")
-                            .put("driver_class", "org.hsqldb.jdbcDriver"))))
-        )
+      new DeploymentOptions().setConfig(new JsonObject().
+        put("httpOptions", new JsonObject().
+          put("host", "localhost").
+          put("port", 8080).
+          put("ssl", true).
+          put("keyPairOptions", new JsonObject().
+            put("path", "src/test/resources/server-keystore.jks").
+            put("password", "wibble")).
+          put("authOptions", new JsonObject().
+            put("provider", "jdbc").
+            put("config", new JsonObject()
+              .put("url", "jdbc:hsqldb:mem:test?shutdown=true")
+              .put("driver_class", "org.hsqldb.jdbcDriver"))))
+      )
     );
   }
 
   public void deployHttpServiceWithMongo(Vertx vertx) throws Exception {
     vertx.deployVerticle("maven:{maven-groupId}:{maven-artifactId}:{maven-version}",
-        new DeploymentOptions().setConfig(new JsonObject().
-                put("httpOptions", new JsonObject().
-                    put("host", "localhost").
-                    put("port", 8080).
-                    put("ssl", true).
-                    put("keyPairOptions", new JsonObject().
-                        put("path", "src/test/resources/server-keystore.jks").
-                        put("password", "wibble")).
-                    put("authOptions", new JsonObject().
-                        put("provider", "mongo").
-                        put("config", new JsonObject().
-                            put("connection_string", "mongodb://localhost:27018"))))
-        )
+      new DeploymentOptions().setConfig(new JsonObject().
+        put("httpOptions", new JsonObject().
+          put("host", "localhost").
+          put("port", 8080).
+          put("ssl", true).
+          put("keyPairOptions", new JsonObject().
+            put("path", "src/test/resources/server-keystore.jks").
+            put("password", "wibble")).
+          put("authOptions", new JsonObject().
+            put("provider", "mongo").
+            put("config", new JsonObject().
+              put("connection_string", "mongodb://localhost:27018"))))
+      )
     );
   }
 
   public void runTelnetService(Vertx vertx) throws Exception {
     ShellService service = ShellService.create(vertx,
-        new ShellServiceOptions().setTelnetOptions(
-            new TelnetTermOptions().
-                setHost("localhost").
-                setPort(4000)
-        )
+      new ShellServiceOptions().setTelnetOptions(
+        new TelnetTermOptions().
+          setHost("localhost").
+          setPort(4000)
+      )
     );
     service.start();
   }
 
   public void runSSHServiceWithShiro(Vertx vertx) throws Exception {
     ShellService service = ShellService.create(vertx,
-        new ShellServiceOptions().setSSHOptions(
-            new SSHTermOptions().
-                setHost("localhost").
-                setPort(5000).
-                setKeyPairOptions(new JksOptions().
-                        setPath("server-keystore.jks").
-                        setPassword("wibble")
-                ).
-                setAuthOptions(new ShiroAuthOptions().
-                        setType(ShiroAuthRealmType.PROPERTIES).
-                        setConfig(new JsonObject().
-                            put("properties_path", "file:/path/to/my/auth.properties"))
-                )
-        )
+      new ShellServiceOptions().setSSHOptions(
+        new SSHTermOptions().
+          setHost("localhost").
+          setPort(5000).
+          setKeyPairOptions(new JksOptions().
+            setPath("server-keystore.jks").
+            setPassword("wibble")
+          ).
+          setAuthOptions(
+            new JsonObject()
+              .put("provider", "shiro")
+              .put("type", "PROPERTIES")
+              .put("config", new JsonObject().
+                put("properties_path", "file:/path/to/my/auth.properties"))
+          )
+      )
     );
     service.start();
   }
 
   public void runSSHServiceWithMongo(Vertx vertx) throws Exception {
     ShellService service = ShellService.create(vertx,
-        new ShellServiceOptions().setSSHOptions(
-            new SSHTermOptions().
-                setHost("localhost").
-                setPort(5000).
-                setKeyPairOptions(new JksOptions().
-                        setPath("server-keystore.jks").
-                        setPassword("wibble")
-                ).
-                setAuthOptions(new MongoAuthOptions().setConfig(new JsonObject().
-                        put("connection_string", "mongodb://localhost:27018"))
-                )
-        )
+      new ShellServiceOptions().setSSHOptions(
+        new SSHTermOptions().
+          setHost("localhost").
+          setPort(5000).
+          setKeyPairOptions(new JksOptions().
+            setPath("server-keystore.jks").
+            setPassword("wibble")
+          ).
+          setAuthOptions(new JsonObject()
+            .put("provider", "mongo")
+            .put("config", new JsonObject().put("connection_string", "mongodb://localhost:27018"))
+          )
+      )
     );
     service.start();
   }
 
   public void runSSHServiceWithJDBC(Vertx vertx) throws Exception {
     ShellService service = ShellService.create(vertx,
-        new ShellServiceOptions().setSSHOptions(
-            new SSHTermOptions().
-                setHost("localhost").
-                setPort(5000).
-                setKeyPairOptions(new JksOptions().
-                        setPath("server-keystore.jks").
-                        setPassword("wibble")
-                ).
-                setAuthOptions(new JDBCAuthOptions().setConfig(new JsonObject()
-                        .put("url", "jdbc:hsqldb:mem:test?shutdown=true")
-                        .put("driver_class", "org.hsqldb.jdbcDriver"))
-                )
-        )
+      new ShellServiceOptions().setSSHOptions(
+        new SSHTermOptions().
+          setHost("localhost").
+          setPort(5000).
+          setKeyPairOptions(new JksOptions().
+            setPath("server-keystore.jks").
+            setPassword("wibble")
+          ).
+          setAuthOptions(new JsonObject()
+            .put("provider", "jdbc")
+            .put("config", new JsonObject()
+              .put("url", "jdbc:hsqldb:mem:test?shutdown=true")
+              .put("driver_class", "org.hsqldb.jdbcDriver"))
+          )
+      )
     );
     service.start();
   }
 
   public void runHttpService(Vertx vertx) throws Exception {
     ShellService service = ShellService.create(vertx,
-        new ShellServiceOptions().setHttpOptions(
-            new HttpTermOptions().
-                setHost("localhost").
-                setPort(8080)
-        )
+      new ShellServiceOptions().setHttpOptions(
+        new HttpTermOptions().
+          setHost("localhost").
+          setPort(8080)
+      )
     );
     service.start();
   }
 
   public void runHTTPServiceWithMongo(Vertx vertx) throws Exception {
     ShellService service = ShellService.create(vertx,
-        new ShellServiceOptions().setHttpOptions(
-            new HttpTermOptions().
-                setHost("localhost").
-                setPort(8080).
-                setAuthOptions(new MongoAuthOptions().setConfig(new JsonObject().
-                        put("connection_string", "mongodb://localhost:27018"))
-                )
-        )
+      new ShellServiceOptions().setHttpOptions(
+        new HttpTermOptions().
+          setHost("localhost").
+          setPort(8080).
+          setAuthOptions(new JsonObject()
+            .put("provider", "mongo")
+            .put("config", new JsonObject()
+              .put("connection_string", "mongodb://localhost:27018"))
+          )
+      )
     );
     service.start();
   }
 
   public void runHTTPServiceWithJDBC(Vertx vertx) throws Exception {
     ShellService service = ShellService.create(vertx,
-        new ShellServiceOptions().setHttpOptions(
-            new HttpTermOptions().
-                setHost("localhost").
-                setPort(8080).
-                setAuthOptions(new JDBCAuthOptions().setConfig(new JsonObject()
-                        .put("url", "jdbc:hsqldb:mem:test?shutdown=true")
-                        .put("driver_class", "org.hsqldb.jdbcDriver"))
-                )
-        )
+      new ShellServiceOptions().setHttpOptions(
+        new HttpTermOptions().
+          setHost("localhost").
+          setPort(8080).
+          setAuthOptions(new JsonObject()
+            .put("provider", "jdbc")
+            .put("config", new JsonObject()
+              .put("url", "jdbc:hsqldb:mem:test?shutdown=true")
+              .put("driver_class", "org.hsqldb.jdbcDriver"))
+          )
+      )
     );
     service.start();
   }
@@ -329,8 +329,8 @@ public class ShellExamples {
 
   public void cliCommand() {
     CLI cli = CLI.create("my-command").
-        addArgument(new Argument().setArgName("my-arg")).
-        addOption(new Option().setShortName("m").setLongName("my-option"));
+      addArgument(new Argument().setArgName("my-arg")).
+      addOption(new Option().setShortName("m").setLongName("my-option"));
     CommandBuilder command = CommandBuilder.command(cli);
     command.processHandler(process -> {
 
@@ -346,8 +346,8 @@ public class ShellExamples {
 
   public void cliCommandWithHelp() {
     CLI cli = CLI.create("my-command").
-        addArgument(new Argument().setArgName("my-arg")).
-        addOption(new Option().setArgName("help").setShortName("h").setLongName("help"));
+      addArgument(new Argument().setArgName("my-arg")).
+      addOption(new Option().setArgName("help").setShortName("h").setLongName("help"));
     CommandBuilder command = CommandBuilder.command(cli);
     command.processHandler(process -> {
       // ...

--- a/src/main/java/io/vertx/ext/shell/impl/ShellAuth.java
+++ b/src/main/java/io/vertx/ext/shell/impl/ShellAuth.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ *
+ *
+ * Copyright (c) 2015 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ *
+ */
+package io.vertx.ext.shell.impl;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxException;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.AuthProvider;
+
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+/**
+ * A simple service loader to decouple the auth providers.
+ */
+public interface ShellAuth {
+
+  String provider();
+
+  AuthProvider create(Vertx vertx, JsonObject config);
+
+  static AuthProvider load(Vertx vertx, JsonObject config) {
+    ServiceLoader<ShellAuth> loader = ServiceLoader.load(ShellAuth.class);
+
+    Iterator<ShellAuth> factories = loader.iterator();
+
+    while (factories.hasNext()) {
+      try {
+        // might fail to start (missing classes for example...
+        ShellAuth auth = factories.next();
+        if (auth != null) {
+          if (auth.provider().equals(config.getString("provider", ""))) {
+            return auth.create(vertx, config);
+          }
+        }
+      } catch (RuntimeException e) {
+        // continue...
+      }
+    }
+    throw new VertxException("Provider not found [" + config.getString("provider", "") + "] / check your classpath");
+  }
+}

--- a/src/main/java/io/vertx/ext/shell/impl/auth/JDBCShellAuth.java
+++ b/src/main/java/io/vertx/ext/shell/impl/auth/JDBCShellAuth.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ *
+ *
+ * Copyright (c) 2015 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ *
+ */
+package io.vertx.ext.shell.impl.auth;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.AuthProvider;
+import io.vertx.ext.auth.jdbc.JDBCAuth;
+import io.vertx.ext.auth.jdbc.JDBCAuthOptions;
+import io.vertx.ext.jdbc.JDBCClient;
+import io.vertx.ext.shell.impl.ShellAuth;
+
+public class JDBCShellAuth implements ShellAuth {
+
+  @Override
+  public String provider() {
+    return "jdbc";
+  }
+
+  @Override
+  public AuthProvider create(Vertx vertx, JsonObject config) {
+    final JDBCAuthOptions options = new JDBCAuthOptions(config);
+    final JDBCClient client;
+
+    if (options.isShared()) {
+      String datasourceName = options.getDatasourceName();
+      if (datasourceName != null) {
+        client = JDBCClient.createShared(vertx, options.getConfig(), datasourceName);
+      } else {
+        client = JDBCClient.createShared(vertx, options.getConfig());
+      }
+    } else {
+      client = JDBCClient.createNonShared(vertx, options.getConfig());
+    }
+
+    final JDBCAuth auth = JDBCAuth.create(vertx, client);
+
+    if (options.getAuthenticationQuery() != null) {
+      auth.setAuthenticationQuery(options.getAuthenticationQuery());
+    }
+    if (options.getRolesQuery() != null) {
+      auth.setRolesQuery(options.getRolesQuery());
+    }
+    if (options.getPermissionsQuery() != null) {
+      auth.setPermissionsQuery(options.getPermissionsQuery());
+    }
+    if (options.getRolesPrefix() != null) {
+      auth.setRolePrefix(options.getRolesPrefix());
+    }
+    return auth;
+  }
+}

--- a/src/main/java/io/vertx/ext/shell/impl/auth/MongoShellAuth.java
+++ b/src/main/java/io/vertx/ext/shell/impl/auth/MongoShellAuth.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ *
+ *
+ * Copyright (c) 2015 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ *
+ */
+package io.vertx.ext.shell.impl.auth;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.AuthProvider;
+import io.vertx.ext.auth.mongo.MongoAuth;
+import io.vertx.ext.auth.mongo.MongoAuthOptions;
+import io.vertx.ext.auth.mongo.MongoAuthOptionsConverter;
+import io.vertx.ext.mongo.MongoClient;
+import io.vertx.ext.shell.impl.ShellAuth;
+
+public class MongoShellAuth implements ShellAuth {
+
+  @Override
+  public String provider() {
+    return "mongo";
+  }
+
+  @Override
+  public AuthProvider create(Vertx vertx, JsonObject config) {
+    final MongoAuthOptions options = new MongoAuthOptions(config);
+    MongoClient client;
+    if (options.getShared()) {
+      String datasourceName = options.getDatasourceName();
+      if (datasourceName != null) {
+        client = MongoClient.createShared(vertx, options.getConfig(), datasourceName);
+      } else {
+        client = MongoClient.createShared(vertx, options.getConfig());
+      }
+    } else {
+      client = MongoClient.createNonShared(vertx, options.getConfig());
+    }
+
+    JsonObject authConfig = new JsonObject();
+    MongoAuthOptionsConverter.toJson(options, authConfig);
+    return MongoAuth.create(client, authConfig);
+  }
+}

--- a/src/main/java/io/vertx/ext/shell/impl/auth/ShiroShellAuth.java
+++ b/src/main/java/io/vertx/ext/shell/impl/auth/ShiroShellAuth.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ *
+ *
+ * Copyright (c) 2015 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ *
+ */
+package io.vertx.ext.shell.impl.auth;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.AuthOptions;
+import io.vertx.ext.auth.AuthProvider;
+import io.vertx.ext.auth.shiro.ShiroAuth;
+import io.vertx.ext.auth.shiro.ShiroAuthOptions;
+import io.vertx.ext.shell.impl.ShellAuth;
+
+public class ShiroShellAuth implements ShellAuth {
+
+  @Override
+  public String provider() {
+    return "shiro";
+  }
+
+  @Override
+  public AuthProvider create(Vertx vertx, JsonObject config) {
+    final ShiroAuthOptions options = new ShiroAuthOptions(config);
+    return ShiroAuth.create(vertx, options);
+  }
+}

--- a/src/main/java/io/vertx/ext/shell/impl/auth/ShiroShellAuth.java
+++ b/src/main/java/io/vertx/ext/shell/impl/auth/ShiroShellAuth.java
@@ -33,7 +33,6 @@ package io.vertx.ext.shell.impl.auth;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.auth.AuthOptions;
 import io.vertx.ext.auth.AuthProvider;
 import io.vertx.ext.auth.shiro.ShiroAuth;
 import io.vertx.ext.auth.shiro.ShiroAuthOptions;

--- a/src/main/java/io/vertx/ext/shell/term/HttpTermOptions.java
+++ b/src/main/java/io/vertx/ext/shell/term/HttpTermOptions.java
@@ -83,7 +83,7 @@ public class HttpTermOptions extends HttpServerOptions {
   private static final String DEFAULT_SOCKJSPATH = "/shell/*";
 
   private SockJSHandlerOptions sockJSHandlerOptions;
-  private AuthOptions authOptions;
+  private JsonObject authOptions;
   private String sockJSPath;
   private Buffer vertsShellJsResource;
   private Buffer termJsResource;
@@ -99,7 +99,6 @@ public class HttpTermOptions extends HttpServerOptions {
     super(json);
     init();
     HttpTermOptionsConverter.fromJson(json, this);
-    authOptions = json.getJsonObject("authOptions") != null ? SSHTermOptions.createAuthOptions(json.getJsonObject("authOptions")) : null;
   }
 
   public HttpTermOptions(HttpTermOptions that) {
@@ -108,6 +107,7 @@ public class HttpTermOptions extends HttpServerOptions {
     vertsShellJsResource = that.vertsShellJsResource != null ? that.vertsShellJsResource.copy() : null;
     termJsResource = that.termJsResource != null ? that.termJsResource.copy() : null;
     shellHtmlResource = that.shellHtmlResource != null ? that.shellHtmlResource.copy() : null;
+    authOptions = that.authOptions != null ? that.authOptions.copy() : null;
     charset = that.charset;
     intputrc = that.intputrc;
   }
@@ -161,7 +161,7 @@ public class HttpTermOptions extends HttpServerOptions {
   /**
    * @return the auth options
    */
-  public AuthOptions getAuthOptions() {
+  public JsonObject getAuthOptions() {
     return authOptions;
   }
 
@@ -171,8 +171,7 @@ public class HttpTermOptions extends HttpServerOptions {
    * @param authOptions the auth options
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
-  public HttpTermOptions setAuthOptions(AuthOptions authOptions) {
+  public HttpTermOptions setAuthOptions(JsonObject authOptions) {
     this.authOptions = authOptions;
     return this;
   }

--- a/src/main/java/io/vertx/ext/shell/term/HttpTermOptions.java
+++ b/src/main/java/io/vertx/ext/shell/term/HttpTermOptions.java
@@ -42,7 +42,6 @@ import io.vertx.core.net.JksOptions;
 import io.vertx.core.net.PemKeyCertOptions;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.core.net.PfxOptions;
-import io.vertx.ext.auth.AuthOptions;
 import io.vertx.ext.shell.term.impl.Helper;
 import io.vertx.ext.web.handler.sockjs.SockJSHandlerOptions;
 

--- a/src/main/java/io/vertx/ext/shell/term/SSHTermOptions.java
+++ b/src/main/java/io/vertx/ext/shell/term/SSHTermOptions.java
@@ -34,16 +34,13 @@ package io.vertx.ext.shell.term;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
-import io.vertx.core.VertxException;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.JksOptions;
 import io.vertx.core.net.KeyCertOptions;
 import io.vertx.core.net.NetServerOptions;
 import io.vertx.core.net.PemKeyCertOptions;
 import io.vertx.core.net.PfxOptions;
-import io.vertx.ext.auth.AuthOptions;
 
-import java.lang.reflect.Constructor;
 import java.nio.charset.StandardCharsets;
 
 /**

--- a/src/main/java/io/vertx/ext/shell/term/SSHTermOptions.java
+++ b/src/main/java/io/vertx/ext/shell/term/SSHTermOptions.java
@@ -62,7 +62,7 @@ public class SSHTermOptions {
   private String host;
   private int port;
   private KeyCertOptions keyPairOptions;
-  private AuthOptions authOptions;
+  private JsonObject authOptions;
   private String defaultCharset;
   private String intputrc;
 
@@ -77,7 +77,7 @@ public class SSHTermOptions {
     this.host = that.host;
     this.port = that.port;
     this.keyPairOptions = that.keyPairOptions != null ? that.keyPairOptions.copy() : null;
-    this.authOptions = that.authOptions != null ? that.authOptions.clone() : null;
+    this.authOptions = that.authOptions != null ? that.authOptions.copy() : null;
     this.defaultCharset = that.defaultCharset;
     this.intputrc = that.intputrc;
   }
@@ -85,7 +85,6 @@ public class SSHTermOptions {
   public SSHTermOptions(JsonObject json) {
     this();
     SSHTermOptionsConverter.fromJson(json, this);
-    authOptions = json.getJsonObject("authOptions") != null ? createAuthOptions(json.getJsonObject("authOptions")) : null;
   }
 
   /**
@@ -163,7 +162,7 @@ public class SSHTermOptions {
   /**
    * @return the auth options
    */
-  public AuthOptions getAuthOptions() {
+  public JsonObject getAuthOptions() {
     return authOptions;
   }
 
@@ -173,8 +172,7 @@ public class SSHTermOptions {
    * @param authOptions the auth options
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
-  public SSHTermOptions setAuthOptions(AuthOptions authOptions) {
+  public SSHTermOptions setAuthOptions(JsonObject authOptions) {
     this.authOptions = authOptions;
     return this;
   }
@@ -210,46 +208,5 @@ public class SSHTermOptions {
   public SSHTermOptions setIntputrc(String intputrc) {
     this.intputrc = intputrc;
     return this;
-  }
-
-  /**
-   * Internal method needed to load auth options supposed by Vert.x Shell.
-   *
-   * Create the auth options from a json value, the implementation makes a lookup on the {@literal provider}
-   * property of the json object and returns the corresponding class.
-   *
-   * @param json the json value
-   * @return the auth provider
-   */
-  static AuthOptions createAuthOptions(JsonObject json) {
-
-    String provider = json.getString("provider", "");
-    String impl;
-    switch (provider) {
-      case "shiro":
-        impl = "io.vertx.ext.auth.shiro.ShiroAuthOptions";
-        break;
-      case "jdbc":
-        impl = "io.vertx.ext.auth.jdbc.JDBCAuthOptions";
-        break;
-      case "mongo":
-        impl = "io.vertx.ext.auth.mongo.MongoAuthOptions";
-        break;
-      default:
-        throw new IllegalArgumentException("Invalid auth provider: " + provider);
-    }
-
-    try {
-      ClassLoader cl = Thread.currentThread().getContextClassLoader();
-      Class<?> optionsClass = cl.loadClass(impl);
-      Constructor<?> ctor = optionsClass.getConstructor(JsonObject.class);
-      return (AuthOptions) ctor.newInstance(json);
-    } catch (ClassNotFoundException e) {
-      throw new VertxException("Provider class not found " + impl + " / check your classpath");
-    } catch(InstantiationException e) {
-      throw new VertxException("Cannot create " + provider +" options", e.getCause());
-    } catch (Exception e) {
-      throw new VertxException("Cannot create " + provider + " options" + provider, e);
-    }
   }
 }

--- a/src/main/java/io/vertx/ext/shell/term/impl/HttpTermServer.java
+++ b/src/main/java/io/vertx/ext/shell/term/impl/HttpTermServer.java
@@ -40,6 +40,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServer;
 import io.vertx.ext.auth.AuthProvider;
+import io.vertx.ext.shell.impl.ShellAuth;
 import io.vertx.ext.shell.term.Term;
 import io.vertx.ext.shell.term.TermServer;
 import io.vertx.ext.shell.term.HttpTermOptions;
@@ -98,7 +99,7 @@ public class HttpTermServer implements TermServer {
     }
 
     if (options.getAuthOptions() != null) {
-      authProvider = options.getAuthOptions().createProvider(vertx);
+      authProvider = ShellAuth.load(vertx, options.getAuthOptions());
     }
 
     if (options.getSockJSPath() != null && options.getSockJSHandlerOptions() != null) {

--- a/src/main/java/io/vertx/ext/shell/term/impl/SSHServer.java
+++ b/src/main/java/io/vertx/ext/shell/term/impl/SSHServer.java
@@ -51,6 +51,7 @@ import io.vertx.core.net.KeyCertOptions;
 import io.vertx.core.net.PfxOptions;
 import io.vertx.core.net.impl.KeyStoreHelper;
 import io.vertx.ext.auth.AuthProvider;
+import io.vertx.ext.shell.impl.ShellAuth;
 import io.vertx.ext.shell.term.SSHTermOptions;
 import io.vertx.ext.shell.term.TermServer;
 import io.vertx.ext.shell.term.Term;
@@ -134,7 +135,7 @@ public class SSHServer implements TermServer {
       return this;
     }
     if (options.getAuthOptions() != null) {
-      authProvider = options.getAuthOptions().createProvider(vertx);
+      authProvider = ShellAuth.load(vertx, options.getAuthOptions());
     }
     Charset defaultCharset = Charset.forName(options.getDefaultCharset());
     listenContext = (ContextInternal) vertx.getOrCreateContext();

--- a/src/main/resources/META-INF/services/io.vertx.ext.shell.impl.ShellAuth
+++ b/src/main/resources/META-INF/services/io.vertx.ext.shell.impl.ShellAuth
@@ -1,0 +1,3 @@
+io.vertx.ext.shell.impl.auth.JDBCShellAuth
+io.vertx.ext.shell.impl.auth.ShiroShellAuth
+io.vertx.ext.shell.impl.auth.MongoShellAuth

--- a/src/test/java/io/vertx/ext/shell/Main.java
+++ b/src/test/java/io/vertx/ext/shell/Main.java
@@ -35,13 +35,11 @@ package io.vertx.ext.shell;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.JksOptions;
-import io.vertx.ext.auth.shiro.ShiroAuthOptions;
-import io.vertx.ext.auth.shiro.ShiroAuthRealmType;
 import io.vertx.ext.shell.command.CommandBuilder;
-import io.vertx.ext.shell.term.SSHTermOptions;
-import io.vertx.ext.shell.term.TelnetTermOptions;
 import io.vertx.ext.shell.command.CommandRegistry;
 import io.vertx.ext.shell.term.HttpTermOptions;
+import io.vertx.ext.shell.term.SSHTermOptions;
+import io.vertx.ext.shell.term.TelnetTermOptions;
 
 /**
  * A simple class for testing from command line directly.
@@ -87,23 +85,24 @@ public class Main {
     // vertx.deployVerticle("command.js");
 
     // Expose the shell
-    ShiroAuthOptions authOptions = new ShiroAuthOptions().
-        setType(ShiroAuthRealmType.PROPERTIES).
-        setConfig(new JsonObject().put("properties_path", "file:src/test/resources/test-auth.properties"));
+    JsonObject authOptions = new JsonObject()
+      .put("provider", "shiro")
+      .put("type", "PROPERTIES")
+      .put("config", new JsonObject().put("properties_path", "file:src/test/resources/test-auth.properties"));
     SSHTermOptions options = new SSHTermOptions().setPort(5001);
     options.setKeyPairOptions(new JksOptions().
-        setPath("src/test/resources/server-keystore.jks").
-        setPassword("wibble")).
-        setAuthOptions(
-            authOptions
-        );
+      setPath("src/test/resources/server-keystore.jks").
+      setPassword("wibble")).
+      setAuthOptions(
+        authOptions
+      );
     ShellService service = ShellService.create(vertx, new ShellServiceOptions().
-        setTelnetOptions(new TelnetTermOptions().setPort(5000)).
-        setSSHOptions(options).
-            setHttpOptions(new HttpTermOptions().
-                    setPort(8080).
-                    setAuthOptions(authOptions)
-            )
+      setTelnetOptions(new TelnetTermOptions().setPort(5000)).
+      setSSHOptions(options).
+      setHttpOptions(new HttpTermOptions().
+        setPort(8080).
+        setAuthOptions(authOptions)
+      )
     );
     service.start();
 

--- a/src/test/java/io/vertx/ext/shell/SSHShellTest.java
+++ b/src/test/java/io/vertx/ext/shell/SSHShellTest.java
@@ -36,7 +36,6 @@ import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.Session;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodStarter;
-import de.flapdoodle.embed.mongo.config.IMongodConfig;
 import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
 import de.flapdoodle.embed.mongo.config.Net;
 import de.flapdoodle.embed.mongo.distribution.Version;
@@ -146,6 +145,7 @@ public class SSHShellTest extends SSHTestBase {
     List<String> SQL  = Arrays.asList(
         "create table user (username varchar(255), password varchar(255), password_salt varchar(255) );",
         "create table user_roles (username varchar(255), role varchar(255));",
+        "create table roles_perms (role VARCHAR(255) NOT NULL, perm VARCHAR(255) NOT NULL);",
         "insert into user values ('tim', 'EC0D6302E35B7E792DF9DA4A5FE0DB3B90FCAB65A6215215771BF96D498A01DA8234769E1CE8269A105E9112F374FDAB2158E7DA58CDC1348A732351C38E12A0', 'C59EB438D1E24CACA2B1A48BC129348589D49303858E493FBE906A9158B7D5DC');"
     );
     Connection conn = DriverManager.getConnection(config().getString("url"));

--- a/src/test/java/io/vertx/ext/shell/SSHShellTest.java
+++ b/src/test/java/io/vertx/ext/shell/SSHShellTest.java
@@ -160,7 +160,9 @@ public class SSHShellTest extends SSHTestBase {
             put("keyPairOptions", new JsonObject().
                 put("path", "src/test/resources/server-keystore.jks").
                 put("password", "wibble")).
-            put("authOptions", new JsonObject().put("provider", "jdbc").put("config",
+            put("authOptions", new JsonObject()
+              .put("provider", "jdbc")
+              .put("config",
                 new JsonObject()
                     .put("url", "jdbc:hsqldb:mem:test?shutdown=true")
                     .put("driver_class", "org.hsqldb.jdbcDriver")))))

--- a/src/test/java/io/vertx/ext/shell/term/HttpTermServerBase.java
+++ b/src/test/java/io/vertx/ext/shell/term/HttpTermServerBase.java
@@ -39,8 +39,8 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.WebSocketConnectOptions;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.auth.AbstractUser;
 import io.vertx.ext.auth.AuthProvider;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -279,10 +279,21 @@ public abstract class HttpTermServerBase {
       String username = authInfo.getString("username");
       String password = authInfo.getString("password");
       if (username.equals("paulo") && password.equals("anothersecret")) {
-        resultHandler.handle(Future.succeededFuture(new AbstractUser() {
+        resultHandler.handle(Future.succeededFuture(new User() {
           @Override
-          protected void doIsPermitted(String permission, Handler<AsyncResult<Boolean>> resultHandler) {
+          public JsonObject attributes() {
+            return new JsonObject();
+          }
+
+          @Override
+          public User isAuthorized(String authority, Handler<AsyncResult<Boolean>> resultHandler) {
             resultHandler.handle(Future.succeededFuture(true));
+            return this;
+          }
+
+          @Override
+          public User clearCache() {
+            return this;
           }
 
           @Override

--- a/src/test/java/io/vertx/ext/shell/term/HttpTermServerBase.java
+++ b/src/test/java/io/vertx/ext/shell/term/HttpTermServerBase.java
@@ -36,14 +36,11 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.WebSocketConnectOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.AbstractUser;
 import io.vertx.ext.auth.AuthProvider;
-import io.vertx.ext.auth.shiro.ShiroAuthOptions;
-import io.vertx.ext.auth.shiro.ShiroAuthRealmType;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -179,7 +176,7 @@ public abstract class HttpTermServerBase {
 
   private void testSize(TestContext context, String uri, int expectedCols, int expectedRows) {
     Async async = context.async();
-    server = createServer(context, new HttpTermOptions().setPort(8080));;
+    server = createServer(context, new HttpTermOptions().setPort(8080));
     server.termHandler(term -> {
       context.assertEquals(expectedCols, term.width());
       context.assertEquals(expectedRows, term.height());
@@ -209,7 +206,7 @@ public abstract class HttpTermServerBase {
 
   private void testResize(TestContext context, JsonObject event, int expectedCols, int expectedRows) {
     Async async = context.async();
-    server = createServer(context, new HttpTermOptions().setPort(8080));;
+    server = createServer(context, new HttpTermOptions().setPort(8080));
     server.termHandler(term -> {
       term.resizehandler(v -> {
         context.assertEquals(expectedCols, term.width());
@@ -228,7 +225,7 @@ public abstract class HttpTermServerBase {
   @Test
   public void testResizeInvalid(TestContext context) {
     Async async = context.async();
-    server = createServer(context, new HttpTermOptions().setPort(8080));;
+    server = createServer(context, new HttpTermOptions().setPort(8080));
     server.termHandler(term -> {
       term.resizehandler(v -> {
         context.fail();
@@ -249,9 +246,10 @@ public abstract class HttpTermServerBase {
   public void testSecure(TestContext context) {
     Async async = context.async();
     server = createServer(context, new HttpTermOptions().setAuthOptions(
-        new ShiroAuthOptions().
-            setType(ShiroAuthRealmType.PROPERTIES).
-            setConfig(new JsonObject().put("properties_path", "classpath:test-auth.properties"))).setPort(8080));
+      new JsonObject()
+        .put("provider", "shiro")
+        .put("type", "PROPERTIES")
+        .put("config", new JsonObject().put("properties_path", "classpath:test-auth.properties"))).setPort(8080));
     server.termHandler(term -> {
       term.write("hello");
     });
@@ -286,10 +284,12 @@ public abstract class HttpTermServerBase {
           protected void doIsPermitted(String permission, Handler<AsyncResult<Boolean>> resultHandler) {
             resultHandler.handle(Future.succeededFuture(true));
           }
+
           @Override
           public JsonObject principal() {
             return new JsonObject().put("username", username);
           }
+
           @Override
           public void setAuthProvider(AuthProvider authProvider) {
           }

--- a/src/test/java/io/vertx/ext/shell/term/SSHServerTest.java
+++ b/src/test/java/io/vertx/ext/shell/term/SSHServerTest.java
@@ -42,8 +42,8 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.JksOptions;
-import io.vertx.ext.auth.AbstractUser;
 import io.vertx.ext.auth.AuthProvider;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.shell.SSHTestBase;
 import io.vertx.ext.shell.term.impl.SSHExec;
 import io.vertx.ext.shell.term.impl.SSHServer;
@@ -247,10 +247,21 @@ public class SSHServerTest extends SSHTestBase {
       String username = authInfo.getString("username");
       String password = authInfo.getString("password");
       if (username.equals("paulo") && password.equals("anothersecret")) {
-        resultHandler.handle(Future.succeededFuture(new AbstractUser() {
+        resultHandler.handle(Future.succeededFuture(new User() {
           @Override
-          protected void doIsPermitted(String permission, Handler<AsyncResult<Boolean>> resultHandler) {
+          public JsonObject attributes() {
+            return new JsonObject();
+          }
+
+          @Override
+          public User isAuthorized(String authority, Handler<AsyncResult<Boolean>> resultHandler) {
             resultHandler.handle(Future.succeededFuture(true));
+            return this;
+          }
+
+          @Override
+          public User clearCache() {
+            return this;
           }
 
           @Override

--- a/src/test/java/io/vertx/ext/shell/term/SSHServerTest.java
+++ b/src/test/java/io/vertx/ext/shell/term/SSHServerTest.java
@@ -44,8 +44,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.JksOptions;
 import io.vertx.ext.auth.AbstractUser;
 import io.vertx.ext.auth.AuthProvider;
-import io.vertx.ext.auth.shiro.ShiroAuthOptions;
-import io.vertx.ext.auth.shiro.ShiroAuthRealmType;
 import io.vertx.ext.shell.SSHTestBase;
 import io.vertx.ext.shell.term.impl.SSHExec;
 import io.vertx.ext.shell.term.impl.SSHServer;
@@ -54,17 +52,9 @@ import io.vertx.ext.unit.TestContext;
 import org.junit.After;
 import org.junit.Test;
 
-import java.io.File;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.Reader;
+import java.io.*;
 import java.net.URL;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -104,7 +94,7 @@ public class SSHServerTest extends SSHTestBase {
     server = TermServer.createSSHTermServer(vertx, options);
     CompletableFuture<Void> fut = new CompletableFuture<>();
     server.termHandler(termHandler);
-    ((SSHServer)server).setExecHandler(execHandler);
+    ((SSHServer) server).setExecHandler(execHandler);
     server.authProvider(authProvider);
     server.listen(ar -> {
       if (ar.succeeded()) {
@@ -156,7 +146,7 @@ public class SSHServerTest extends SSHTestBase {
         count = 0;
       } else {
         count--;
-        sb.append((char)code);
+        sb.append((char) code);
       }
     }
     assertEquals("hello", sb.toString());
@@ -262,10 +252,12 @@ public class SSHServerTest extends SSHTestBase {
           protected void doIsPermitted(String permission, Handler<AsyncResult<Boolean>> resultHandler) {
             resultHandler.handle(Future.succeededFuture(true));
           }
+
           @Override
           public JsonObject principal() {
             return new JsonObject().put("username", username);
           }
+
           @Override
           public void setAuthProvider(AuthProvider authProvider) {
           }
@@ -280,7 +272,7 @@ public class SSHServerTest extends SSHTestBase {
       async.complete();
     };
     startShell(new SSHTermOptions().setPort(5000).setHost("localhost").setKeyPairOptions(
-        new JksOptions().setPath("src/test/resources/server-keystore.jks").setPassword("wibble")));
+      new JksOptions().setPath("src/test/resources/server-keystore.jks").setPassword("wibble")));
     Session session = createSession("paulo", "anothersecret", false);
     session.connect();
     Channel channel = session.openChannel("shell");
@@ -298,7 +290,7 @@ public class SSHServerTest extends SSHTestBase {
       context.fail();
     };
     startShell(new SSHTermOptions().setPort(5000).setHost("localhost").setKeyPairOptions(
-        new JksOptions().setPath("src/test/resources/server-keystore.jks").setPassword("wibble")));
+      new JksOptions().setPath("src/test/resources/server-keystore.jks").setPassword("wibble")));
     Session session = createSession("paulo", "anothersecret", false);
     try {
       session.connect();
@@ -316,9 +308,12 @@ public class SSHServerTest extends SSHTestBase {
       term.close();
     };
     startShell(new SSHTermOptions().setDefaultCharset("ISO_8859_1").setPort(5000).setHost("localhost").setKeyPairOptions(
-        new JksOptions().setPath("src/test/resources/server-keystore.jks").setPassword("wibble")).
-        setAuthOptions(new ShiroAuthOptions().setType(ShiroAuthRealmType.PROPERTIES).setConfig(
-            new JsonObject().put("properties_path", "classpath:test-auth.properties"))));
+      new JksOptions().setPath("src/test/resources/server-keystore.jks").setPassword("wibble")).
+      setAuthOptions(new JsonObject()
+        .put("provider", "shiro")
+        .put("type", "PROPERTIES")
+        .put("config",
+          new JsonObject().put("properties_path", "classpath:test-auth.properties"))));
     Session session = createSession("paulo", "secret", false);
     session.connect();
     Channel channel = session.openChannel("shell");
@@ -334,9 +329,12 @@ public class SSHServerTest extends SSHTestBase {
     File f = new File(url.toURI());
     termHandler = Term::close;
     startShell(new SSHTermOptions().setIntputrc(f.getAbsolutePath()).setPort(5000).setHost("localhost").setKeyPairOptions(
-        new JksOptions().setPath("src/test/resources/server-keystore.jks").setPassword("wibble")).
-        setAuthOptions(new ShiroAuthOptions().setType(ShiroAuthRealmType.PROPERTIES).setConfig(
-            new JsonObject().put("properties_path", "classpath:test-auth.properties"))));
+      new JksOptions().setPath("src/test/resources/server-keystore.jks").setPassword("wibble")).
+      setAuthOptions(new JsonObject()
+        .put("provider", "shiro")
+        .put("type", "PROPERTIES")
+        .put("config",
+          new JsonObject().put("properties_path", "classpath:test-auth.properties"))));
     Session session = createSession("paulo", "secret", false);
     session.connect();
     Channel channel = session.openChannel("shell");


### PR DESCRIPTION
Currently only `jdbc`, `mongo` and `shiro` are valid forms of auth providers for shell. This is because the contract of data object was *abused* on these auth providers to also instantiate a provider.

This PR will remove this dependency and allow other providers to be used if the service loader is implemented.

This also removed the only dependency on this interface on auth, so it can be cleared to be removed in a future release, as it assumes the options object can create a provider, which is wrong as it also creates database connections that are not managed or exposed to the end user.