### PR TITLE
Should return the port of the actual server.

### DIFF
--- a/src/main/java/io/vertx/ext/shell/term/impl/HttpTermServer.java
+++ b/src/main/java/io/vertx/ext/shell/term/impl/HttpTermServer.java
@@ -153,7 +153,7 @@ public class HttpTermServer implements TermServer {
 
   @Override
   public int actualPort() {
-    return -1;
+    return server.actualPort();
   }
 
   @Override


### PR DESCRIPTION
Motivation:

I think it is a bug.  It should not always return -1.
It should be the actual port. If I set it to 0, the actual port will not be found.
(I think **TelnetTermServer** is correct)

Conformance:
Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
