### PR TITLE
Add spotless plugin and remove unused imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,8 +190,17 @@
   </dependencies>
 
   <build>
-
     <plugins>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <java>
+            <removeUnusedImports />
+          </java>
+        </configuration>
+      </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>

--- a/src/main/java/io/vertx/ext/shell/ShellService.java
+++ b/src/main/java/io/vertx/ext/shell/ShellService.java
@@ -34,8 +34,6 @@ package io.vertx.ext.shell;
 
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.ext.shell.impl.ShellServiceImpl;
 

--- a/src/main/java/io/vertx/ext/shell/term/HttpTermOptions.java
+++ b/src/main/java/io/vertx/ext/shell/term/HttpTermOptions.java
@@ -38,10 +38,6 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.ClientAuth;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.net.JksOptions;
-import io.vertx.core.net.PemKeyCertOptions;
-import io.vertx.core.net.PemTrustOptions;
-import io.vertx.core.net.PfxOptions;
 import io.vertx.ext.shell.term.impl.Helper;
 import io.vertx.ext.web.handler.sockjs.SockJSHandlerOptions;
 

--- a/src/main/java/io/vertx/ext/shell/term/TelnetTermOptions.java
+++ b/src/main/java/io/vertx/ext/shell/term/TelnetTermOptions.java
@@ -36,11 +36,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.net.JksOptions;
 import io.vertx.core.net.NetServerOptions;
-import io.vertx.core.net.PemKeyCertOptions;
-import io.vertx.core.net.PemTrustOptions;
-import io.vertx.core.net.PfxOptions;
 
 import java.nio.charset.StandardCharsets;
 

--- a/src/main/java/io/vertx/ext/shell/term/impl/SSHServer.java
+++ b/src/main/java/io/vertx/ext/shell/term/impl/SSHServer.java
@@ -45,27 +45,19 @@ import io.vertx.ext.shell.term.SSHTermOptions;
 import io.vertx.ext.shell.term.Term;
 import io.vertx.ext.shell.term.TermServer;
 import org.apache.sshd.common.future.CloseFuture;
-import org.apache.sshd.common.future.SshFutureListener;
 import org.apache.sshd.common.keyprovider.AbstractKeyPairProvider;
 import org.apache.sshd.common.keyprovider.KeyPairProvider;
 import org.apache.sshd.common.session.SessionContext;
-import org.apache.sshd.server.Environment;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.auth.AsyncAuthException;
-import org.apache.sshd.server.channel.ChannelSession;
-import org.apache.sshd.server.command.Command;
-import org.apache.sshd.server.shell.ShellFactory;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.nio.charset.Charset;
 import java.security.*;
 import java.security.cert.Certificate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.sshd.server.SshServer.DEFAULT_SERVICE_FACTORIES;


### PR DESCRIPTION
Added spotless plugin to remove unused imports. I have just added the goal of removing unused imports, this can be further extended to impose a code style, import order etc.

cc @vietj I believe this will help with checks. You can use goal = `spotless:apply` to remove unused imports now.